### PR TITLE
pull-factory-config.md: Add note about changing permissions

### DIFF
--- a/src/data/faq/zxw/pull-factory-config.md
+++ b/src/data/faq/zxw/pull-factory-config.md
@@ -14,6 +14,15 @@ The `factory_config.xml` file is a device/vendor specific configuration file tha
     ```sh
     adb pull /mnt/privdata1/zxw_factory_config.xml
     ```
+    If this command fails with a 'Permission Denied' error, you will need to chaage the permissions on the file in order to pull/copy it:
+   ```sh
+   adb shell
+   su
+   chmod +r /mnt/privdata1/zxw_factory_config.xml
+   exit
+   exit
+   ```
+   Then re-run the `adb pull` command above
 6. Disconnect
     ```sh
     adb disconnect


### PR DESCRIPTION
On some (all?) ZXW units, the default permissions on the factory_config.xml are to allow read/write only from the system user/group, which means that the `adb pull` command will fail. Add a note on how to change the permissions using `adb shell` in order to be able to pull the file.